### PR TITLE
perf(shouldHideHintAfterFirstActivation): added shouldHideHintAfterFi…

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@blacklab/react-image-magnify",
-  "version": "3.4.1",
+  "version": "4.1.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@blacklab/react-image-magnify",
-      "version": "3.4.1",
+      "version": "4.1.1",
       "license": "MIT",
       "devDependencies": {
         "@babel/core": "^7.17.8",
@@ -85,7 +85,7 @@
         "@react-hook/resize-observer": "^1.2.5",
         "detect-it": "4.0.1",
         "react": "^16.8 || ^17.0.0 || ^18.0",
-        "react-dom": "^16.8 || ^17.0.0 ^18.0",
+        "react-dom": "^16.8 || ^17.0.0 || ^18.0",
         "react-popper": "^2.2.5"
       }
     },
@@ -3628,20 +3628,6 @@
       },
       "engines": {
         "node": ">=8.9.0"
-      }
-    },
-    "node_modules/@mdx-js/loader/node_modules/react": {
-      "version": "17.0.2",
-      "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-      "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "dev": true,
-      "peer": true,
-      "dependencies": {
-        "loose-envify": "^1.1.0",
-        "object-assign": "^4.1.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
       }
     },
     "node_modules/@mdx-js/mdx": {
@@ -41714,8 +41700,7 @@
           "version": "1.6.22",
           "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
           "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "loader-utils": {
           "version": "2.0.0",
@@ -41726,17 +41711,6 @@
             "big.js": "^5.2.2",
             "emojis-list": "^3.0.0",
             "json5": "^2.1.2"
-          }
-        },
-        "react": {
-          "version": "17.0.2",
-          "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
-          "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-          "dev": true,
-          "peer": true,
-          "requires": {
-            "loose-envify": "^1.1.0",
-            "object-assign": "^4.1.1"
           }
         }
       }
@@ -41966,8 +41940,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-1.0.4.tgz",
       "integrity": "sha512-mLUsMkgP7K/cnFEw07kWqXGF5LKrOkD+lhCrKvPHXWDywAwuDUeDwWBpc69XK3pNX0uKiVt8g5z96PJ6z9xCFA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@octokit/plugin-rest-endpoint-methods": {
       "version": "5.13.0",
@@ -42066,15 +42039,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/@react-hook/latest/-/latest-1.0.3.tgz",
       "integrity": "sha512-dy6duzl+JnAZcDbNTfmaP3xHiKtbXYOaz3G51MGVljh548Y8MWzTr+PHLOfvpypEVW9zwvl+VyKjbWKEVbV1Rg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@react-hook/passive-layout-effect": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/@react-hook/passive-layout-effect/-/passive-layout-effect-1.2.1.tgz",
       "integrity": "sha512-IwEphTD75liO8g+6taS+4oqz+nnroocNfWVHWz7j+N+ZO2vYrc6PV1q7GQhuahL0IOR7JccFTsFKQ/mb6iZWAg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@react-hook/resize-observer": {
       "version": "1.2.5",
@@ -42422,8 +42393,7 @@
                   "version": "1.2.1",
                   "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.2.1.tgz",
                   "integrity": "sha512-6+X1FLlIcjvFMAeAD/hcxDT8tmyrWnbSPMU0EnxQuDLIxokuFzWliXBiYZuGIx+mrAMLBw0WFfCkaPw8ebzAhw==",
-                  "dev": true,
-                  "requires": {}
+                  "dev": true
                 },
                 "use-latest": {
                   "version": "1.2.0",
@@ -42623,8 +42593,7 @@
                       "version": "1.2.1",
                       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.2.1.tgz",
                       "integrity": "sha512-6+X1FLlIcjvFMAeAD/hcxDT8tmyrWnbSPMU0EnxQuDLIxokuFzWliXBiYZuGIx+mrAMLBw0WFfCkaPw8ebzAhw==",
-                      "dev": true,
-                      "requires": {}
+                      "dev": true
                     },
                     "use-latest": {
                       "version": "1.2.0",
@@ -42739,8 +42708,7 @@
                       "version": "1.2.1",
                       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.2.1.tgz",
                       "integrity": "sha512-6+X1FLlIcjvFMAeAD/hcxDT8tmyrWnbSPMU0EnxQuDLIxokuFzWliXBiYZuGIx+mrAMLBw0WFfCkaPw8ebzAhw==",
-                      "dev": true,
-                      "requires": {}
+                      "dev": true
                     },
                     "use-latest": {
                       "version": "1.2.0",
@@ -43012,8 +42980,7 @@
               "version": "1.6.22",
               "resolved": "https://registry.npmjs.org/@mdx-js/react/-/react-1.6.22.tgz",
               "integrity": "sha512-TDoPum4SHdfPiGSAaRBw7ECyI8VaHpK8GJugbJIJuqyh6kzw9ZLJZW3HGL3NNrJGxcAixUvqROm+YuQOo5eXtg==",
-              "dev": true,
-              "requires": {}
+              "dev": true
             },
             "@storybook/builder-webpack4": {
               "version": "6.4.20",
@@ -43452,8 +43419,7 @@
                   "version": "1.2.1",
                   "resolved": "https://registry.npmjs.org/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz",
                   "integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
-                  "dev": true,
-                  "requires": {}
+                  "dev": true
                 }
               }
             },
@@ -43515,8 +43481,7 @@
                       "version": "1.2.1",
                       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.2.1.tgz",
                       "integrity": "sha512-6+X1FLlIcjvFMAeAD/hcxDT8tmyrWnbSPMU0EnxQuDLIxokuFzWliXBiYZuGIx+mrAMLBw0WFfCkaPw8ebzAhw==",
-                      "dev": true,
-                      "requires": {}
+                      "dev": true
                     },
                     "use-latest": {
                       "version": "1.2.0",
@@ -44256,8 +44221,7 @@
                       "version": "1.2.1",
                       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.2.1.tgz",
                       "integrity": "sha512-6+X1FLlIcjvFMAeAD/hcxDT8tmyrWnbSPMU0EnxQuDLIxokuFzWliXBiYZuGIx+mrAMLBw0WFfCkaPw8ebzAhw==",
-                      "dev": true,
-                      "requires": {}
+                      "dev": true
                     },
                     "use-latest": {
                       "version": "1.2.0",
@@ -44370,8 +44334,7 @@
                       "version": "1.2.1",
                       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.2.1.tgz",
                       "integrity": "sha512-6+X1FLlIcjvFMAeAD/hcxDT8tmyrWnbSPMU0EnxQuDLIxokuFzWliXBiYZuGIx+mrAMLBw0WFfCkaPw8ebzAhw==",
-                      "dev": true,
-                      "requires": {}
+                      "dev": true
                     },
                     "use-latest": {
                       "version": "1.2.0",
@@ -44460,8 +44423,7 @@
                       "version": "1.2.1",
                       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.2.1.tgz",
                       "integrity": "sha512-6+X1FLlIcjvFMAeAD/hcxDT8tmyrWnbSPMU0EnxQuDLIxokuFzWliXBiYZuGIx+mrAMLBw0WFfCkaPw8ebzAhw==",
-                      "dev": true,
-                      "requires": {}
+                      "dev": true
                     },
                     "use-latest": {
                       "version": "1.2.0",
@@ -44575,8 +44537,7 @@
                       "version": "1.2.1",
                       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.2.1.tgz",
                       "integrity": "sha512-6+X1FLlIcjvFMAeAD/hcxDT8tmyrWnbSPMU0EnxQuDLIxokuFzWliXBiYZuGIx+mrAMLBw0WFfCkaPw8ebzAhw==",
-                      "dev": true,
-                      "requires": {}
+                      "dev": true
                     },
                     "use-latest": {
                       "version": "1.2.0",
@@ -45855,8 +45816,7 @@
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
           "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -46162,8 +46122,7 @@
                   "version": "1.2.1",
                   "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.2.1.tgz",
                   "integrity": "sha512-6+X1FLlIcjvFMAeAD/hcxDT8tmyrWnbSPMU0EnxQuDLIxokuFzWliXBiYZuGIx+mrAMLBw0WFfCkaPw8ebzAhw==",
-                  "dev": true,
-                  "requires": {}
+                  "dev": true
                 },
                 "use-latest": {
                   "version": "1.2.0",
@@ -47504,8 +47463,7 @@
                       "version": "1.2.1",
                       "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.2.1.tgz",
                       "integrity": "sha512-6+X1FLlIcjvFMAeAD/hcxDT8tmyrWnbSPMU0EnxQuDLIxokuFzWliXBiYZuGIx+mrAMLBw0WFfCkaPw8ebzAhw==",
-                      "dev": true,
-                      "requires": {}
+                      "dev": true
                     },
                     "use-latest": {
                       "version": "1.2.0",
@@ -48523,8 +48481,7 @@
                               "version": "1.2.1",
                               "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.2.1.tgz",
                               "integrity": "sha512-6+X1FLlIcjvFMAeAD/hcxDT8tmyrWnbSPMU0EnxQuDLIxokuFzWliXBiYZuGIx+mrAMLBw0WFfCkaPw8ebzAhw==",
-                              "dev": true,
-                              "requires": {}
+                              "dev": true
                             },
                             "use-latest": {
                               "version": "1.2.0",
@@ -48833,8 +48790,7 @@
                               "version": "1.2.1",
                               "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.2.1.tgz",
                               "integrity": "sha512-6+X1FLlIcjvFMAeAD/hcxDT8tmyrWnbSPMU0EnxQuDLIxokuFzWliXBiYZuGIx+mrAMLBw0WFfCkaPw8ebzAhw==",
-                              "dev": true,
-                              "requires": {}
+                              "dev": true
                             },
                             "use-latest": {
                               "version": "1.2.0",
@@ -49148,8 +49104,7 @@
                                   "version": "1.2.1",
                                   "resolved": "https://registry.npmjs.org/use-composed-ref/-/use-composed-ref-1.2.1.tgz",
                                   "integrity": "sha512-6+X1FLlIcjvFMAeAD/hcxDT8tmyrWnbSPMU0EnxQuDLIxokuFzWliXBiYZuGIx+mrAMLBw0WFfCkaPw8ebzAhw==",
-                                  "dev": true,
-                                  "requires": {}
+                                  "dev": true
                                 },
                                 "use-latest": {
                                   "version": "1.2.0",
@@ -50494,8 +50449,7 @@
           "version": "1.2.1",
           "resolved": "https://registry.npmjs.org/webpack-filter-warnings-plugin/-/webpack-filter-warnings-plugin-1.2.1.tgz",
           "integrity": "sha512-Ez6ytc9IseDMLPo0qCuNNYzgtUl8NovOqjIq4uAU8LTD4uoa1w1KpZyyzFtLTEMZpkkOkLfL9eN+KGYdk1Qtwg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         },
         "webpack-sources": {
           "version": "1.4.3",
@@ -50520,8 +50474,7 @@
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
           "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -51684,8 +51637,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-1.1.1.tgz",
       "integrity": "sha512-1FBc1f9G4P/AxMqIgfZgeOTuRnwZMten8E7zap5zgpPInnCrP8D4Q81+4CWIch8i/Nf7nXjP0v6CjjbHOrXhKg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@webpack-cli/info": {
       "version": "1.4.1",
@@ -51700,8 +51652,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-1.6.1.tgz",
       "integrity": "sha512-gNGTiTrjEVQ0OcVnzsRSqTxaBSr+dmTfm+qJsCDluky8uhdLWep7Gcr62QsAKHTMxjCS/8nEITsmFAhfIx+QSw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "@wojtekmaj/enzyme-adapter-react-17": {
       "version": "0.6.7",
@@ -51809,15 +51760,13 @@
       "version": "1.8.0",
       "resolved": "https://registry.npmjs.org/acorn-import-assertions/-/acorn-import-assertions-1.8.0.tgz",
       "integrity": "sha512-m7VZ3jwz4eK6A4Vtt8Ew1/mNbP24u0FhdyfA7fSvnJR6LMdfOYnmuIrrJAgrYfYJ10F/otaHTtrtrtmHdMNzEw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-jsx": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-5.3.2.tgz",
       "integrity": "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "acorn-walk": {
       "version": "7.2.0",
@@ -51891,8 +51840,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ajv-errors/-/ajv-errors-1.0.1.tgz",
       "integrity": "sha512-DCRfO/4nQ+89p/RK43i8Ezd41EqdGIU4ld7nGF8OQ14oc/we5rEntLCUa7+jrn3nn83BosfwZA0wb4pon2o8iQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ajv-formats": {
       "version": "2.1.1",
@@ -51927,8 +51875,7 @@
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
       "integrity": "sha512-5p6WTN0DdTGVQk6VjcEju19IgaHudalcfabD7yhDGeA6bcQnmL+CpveLJq/3hvfwd1aof6L386Ougkx6RfyMIQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ansi-align": {
       "version": "3.0.1",
@@ -52587,8 +52534,7 @@
       "version": "0.3.8",
       "resolved": "https://registry.npmjs.org/babel-plugin-named-asset-import/-/babel-plugin-named-asset-import-0.3.8.tgz",
       "integrity": "sha512-WXiAc++qo7XcJ1ZnTYGtLxmBCVbddAml3CEXgWaBzNzLNoxtQ8AiGEFDMOhot9XjTCQbvP5E77Fj9Gk924f00Q==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "babel-plugin-polyfill-corejs2": {
       "version": "0.3.1",
@@ -55958,8 +55904,7 @@
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-chai-friendly/-/eslint-plugin-chai-friendly-0.7.2.tgz",
       "integrity": "sha512-LOIfGx5sZZ5FwM1shr2GlYAWV9Omdi+1/3byuVagvQNoGUuU0iHhp7AfjA1uR+4dJ4Isfb4+FwBJgQajIw9iAg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-plugin-import": {
       "version": "2.25.4",
@@ -56084,8 +56029,7 @@
       "version": "4.4.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.4.0.tgz",
       "integrity": "sha512-U3RVIfdzJaeKDQKEJbz5p3NW8/L80PCATJAfuojwbaEL+gBjfGdhUcGde+WGUW46Q5sr/NgxevsIiDtNXrvZaQ==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "eslint-scope": {
       "version": "5.1.1",
@@ -57943,8 +57887,7 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/icss-utils/-/icss-utils-5.1.0.tgz",
       "integrity": "sha512-soFhflCVWLfRNOPU3iv5Z9VUdT44xFRbzjLsEzSr5AQmgqPMTHdU3PMT1Cf1ssx8fLNJDA1juftYl+PUcv3MqA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "ieee754": {
       "version": "1.2.1",
@@ -59362,8 +59305,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/jest-pnp-resolver/-/jest-pnp-resolver-1.2.2.tgz",
       "integrity": "sha512-olV41bKSMm8BdnuMsewT4jqlZ8+3TCARAXjZGT9jcoSnrfUnRCqnMoF9XEeoWjbzObpqF9dRhHQj0Xb9QdF6/w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "jest-regex-util": {
       "version": "27.5.1",
@@ -60480,8 +60422,7 @@
       "version": "7.1.7",
       "resolved": "https://registry.npmjs.org/markdown-to-jsx/-/markdown-to-jsx-7.1.7.tgz",
       "integrity": "sha512-VI3TyyHlGkO8uFle0IOibzpO1c1iJDcXcS/zBrQrXQQvJ2tpdwVzVZ7XdKsyRz1NdRmre4dqQkMZzUHaKIG/1w==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "marked": {
       "version": "4.0.12",
@@ -63832,8 +63773,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/postcss-modules-extract-imports/-/postcss-modules-extract-imports-3.0.0.tgz",
       "integrity": "sha512-bdHleFnP3kZ4NYDhuGlVK+CMrQ/pqUm8bx/oGL93K6gVwiclvX5x0n76fYMKuIGKzlABOy13zsvqjb0f92TEXw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "postcss-modules-local-by-default": {
       "version": "4.0.0",
@@ -64271,8 +64211,7 @@
       "version": "5.5.1",
       "resolved": "https://registry.npmjs.org/react-colorful/-/react-colorful-5.5.1.tgz",
       "integrity": "sha512-M1TJH2X3RXEt12sWkpa6hLc/bbYS0H6F4rIqjQZ+RxNBstpY67d9TrFXtqdZwhpmBXcCwEi7stKqFue3ZRkiOg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-docgen": {
       "version": "5.4.0",
@@ -64304,8 +64243,7 @@
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/react-docgen-typescript/-/react-docgen-typescript-2.2.2.tgz",
       "integrity": "sha512-tvg2ZtOpOi6QDwsb3GZhOjDkkX0h8Z2gipvTg6OVMUyoYoURhEiRNePT8NZItTVCDh39JJHnLdfCOkzoLbFnTg==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-dom": {
       "version": "18.0.0",
@@ -64359,8 +64297,7 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/react-refresh-typescript/-/react-refresh-typescript-2.0.4.tgz",
       "integrity": "sha512-ySsBExEFik5Jjf7NoXtFbzUk2rYWM4gF5gg+wRTNmp9p7B2uMpAAa339FHWqmB8EAr0e6mzzskAXxc0Jd04fBw==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "react-router": {
       "version": "6.3.0",
@@ -67831,8 +67768,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/use-isomorphic-layout-effect/-/use-isomorphic-layout-effect-1.1.2.tgz",
       "integrity": "sha512-49L8yCO3iGT/ZF9QttjwLF/ZD9Iwto5LnH5LmEdk/6cFmXddqi2ulF0edxTwjj+7mqvpVVGQWvbXZdn32wRSHA==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "util": {
       "version": "0.11.1",
@@ -68661,8 +68597,7 @@
           "version": "8.5.0",
           "resolved": "https://registry.npmjs.org/ws/-/ws-8.5.0.tgz",
           "integrity": "sha512-BWX0SWVgLPzYwF8lTzEy1egjhS4S4OEAHfsO8o65WOVsrnSRGaSiUaa9e0ggGlkMTtBlmOpEXiie9RUcBO86qg==",
-          "dev": true,
-          "requires": {}
+          "dev": true
         }
       }
     },
@@ -68902,8 +68837,7 @@
       "version": "7.5.7",
       "resolved": "https://registry.npmjs.org/ws/-/ws-7.5.7.tgz",
       "integrity": "sha512-KMvVuFzpKBuiIXW3E4u3mySRO2/mCHSyZDJQM5NQ9Q9KHWHWh0NHgfbRMLLrceUK5qAL4ytALJbpRMjixFZh8A==",
-      "dev": true,
-      "requires": {}
+      "dev": true
     },
     "xml": {
       "version": "1.0.1",

--- a/src/ReactImageMagnify.tsx
+++ b/src/ReactImageMagnify.tsx
@@ -14,6 +14,7 @@ import { MagnifyContainerPortal } from 'src/MagnifyContainerPortal';
 import { NegativeSpaceLens } from 'src/lens/negative-space';
 import { PositiveSpaceLens } from 'src/lens/positive-space';
 import { DefaultHint } from 'src/hint/DefaultHint';
+import { DisplayUntilActive } from 'src/hint/DisplayUntilActive';
 import { getLensCursorOffset } from 'src/lib/lens';
 import { getEnlargedImageContainerDimension } from 'src/lib/dimensions';
 import { CursorPosition } from 'src/CursorPosition';
@@ -63,6 +64,7 @@ export const ReactImageMagnify = (props: ReactImageMagnifyProps): JSX.Element =>
         portalProps: portalPropsProp,
         shouldUsePositiveSpaceLens = false,
         style,
+        shouldHideHintAfterFirstActivation,
         ...rest
     } = props;
     const { onLoad, ...usabledImageProps } = imageProps;
@@ -219,20 +221,6 @@ export const ReactImageMagnify = (props: ReactImageMagnifyProps): JSX.Element =>
         }
     };
 
-    const HintComponentOrNull = activationInteractionHint && shouldShowHint(activationInteractionHint)
-        ? (
-            <HintComponent
-                {...hintProps}
-                hintTextMouse={hintProps?.hintTextMouse || `${capitalize(activationInteractionHint)} to Zoom`}
-                hintTextTouch={hintProps?.hintTextTouch || 'Long-Touch to Zoom'}
-                isMouseDetected={isMouseDetected}
-                isTouchDetected={isTouchDetected}
-                style={generateHintStyle(hintProps?.style)}
-                onClick={lockedByHintInteraction ? handleHintClick : undefined}
-                onTouchEnd={lockedByHintInteraction ? handleHintTouchEnd : undefined}
-            />
-        ) : null;
-
     const LensComponent = LensComponentProp || shouldUsePositiveSpaceLens ? PositiveSpaceLens : NegativeSpaceLens;
 
     ///
@@ -252,7 +240,6 @@ export const ReactImageMagnify = (props: ReactImageMagnifyProps): JSX.Element =>
         }
     // eslint-disable-next-line react-hooks/exhaustive-deps
     }, []);
-
     return (
         <CursorPosition
             shouldStopTouchMovePropagation
@@ -274,7 +261,25 @@ export const ReactImageMagnify = (props: ReactImageMagnifyProps): JSX.Element =>
                     />
                     {imageLoaded && (
                         <>
-                            {HintComponentOrNull}
+                            {activationInteractionHint && shouldShowHint(activationInteractionHint)
+                                ? (
+                                    <DisplayUntilActive {...{
+                                        isActive,
+                                        shouldHideHintAfterFirstActivation,
+                                    }}
+                                    >
+                                        <HintComponent
+                                            {...hintProps}
+                                            hintTextMouse={hintProps?.hintTextMouse || `${capitalize(activationInteractionHint)} to Zoom`}
+                                            hintTextTouch={hintProps?.hintTextTouch || 'Long-Touch to Zoom'}
+                                            isMouseDetected={isMouseDetected}
+                                            isTouchDetected={isTouchDetected}
+                                            style={generateHintStyle(hintProps?.style)}
+                                            onClick={lockedByHintInteraction ? handleHintClick : undefined}
+                                            onTouchEnd={lockedByHintInteraction ? handleHintTouchEnd : undefined}
+                                        />
+                                    </DisplayUntilActive>
+                                ) : null}
                             {shouldShowLens && !lockedByHintInteraction && (
                                 <LensComponent
                                     cursorOffset={cursorOffset}

--- a/src/hint/DisplayUntilActive.tsx
+++ b/src/hint/DisplayUntilActive.tsx
@@ -1,0 +1,20 @@
+import { useState } from 'react';
+import type { DisplayUntilActiveProps } from 'src/types';
+
+export type PropTypes = DisplayUntilActiveProps;
+
+export const DisplayUntilActive = (props: PropTypes): JSX.Element | null => {
+    const {
+        children,
+        isActive,
+        shouldHideHintAfterFirstActivation,
+    } = props;
+    const [hasShown, setHasShown] = useState(false);
+    const shouldShow = !isActive && (!hasShown || !shouldHideHintAfterFirstActivation);
+
+    if (isActive && !hasShown) {
+        setHasShown(true);
+    }
+
+    return shouldShow ? children : null;
+};

--- a/src/stories/ReactImageMagnify.stories.tsx
+++ b/src/stories/ReactImageMagnify.stories.tsx
@@ -46,6 +46,26 @@ MagnifyOnHoverWithHint.args = {
     },
 };
 
+export const MagnifyOnHoverWithHintThatDeactivates = Template.bind({});
+MagnifyOnHoverWithHintThatDeactivates.args = {
+    activationInteractionHint: 'hover',
+    shouldHideHintAfterFirstActivation: true,
+    imageProps: {
+        alt: 'example small image',
+        src: 'https://picsum.photos/id/1018/200',
+        height: 200,
+        width: 200,
+    },
+    magnifiedImageProps: {
+        src: 'https://picsum.photos/id/1018/800',
+        height: 600,
+        width: 600,
+    },
+    portalProps: {
+        horizontalOffset: 10,
+    },
+};
+
 export const MagnifyOnHintClick = Template.bind({});
 MagnifyOnHintClick.args = {
     activationInteractionHint: 'click',

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,6 +117,11 @@ export type ChildProps = {
     position: Point;
 };
 
+export interface DisplayUntilActiveProps {
+    children: JSX.Element;
+    isActive: boolean;
+    shouldHideHintAfterFirstActivation?: boolean;
+}
 export interface CursorPositionProps extends HTMLProps<HTMLDivElement> {
     activationInteractionMouse: Interactions['click'] | Interactions['hover'];
     activationInteractionTouch: Interactions['press'] | Interactions['tap'] | Interactions['touch'];


### PR DESCRIPTION
Adding functionality for shouldHideHintAfterFirst activation.
This used to work on the old react-image-magnify but seems that it doesn't on the forked one.
Can be considered a major release since currently the hint component is shown and this would change after the changes proposed